### PR TITLE
Fix .eslintignore does not work

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-dist/
-lib/
-node_modules/
-jest.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,5 +50,11 @@
     "node": true,
     "es6": true,
     "jest/globals": true
-  }
+  },
+  "ignorePatterns": [
+    "dist/",
+    "lib/",
+    "node_modules/",
+    "jest.config.js"
+  ]
 }


### PR DESCRIPTION
`.eslintignore` does not work for yarn workspaces. This will use `ignorePatterns` instead.

```console
% yarn lint --debug
...
  eslintrc:ignore-pattern Create with: [ IgnorePattern { patterns: [ '/**/node_modules/*' ], basePath: '/typescript-actions-monorepo/hello-world', loose: false }, IgnorePattern { patterns: [ 'dist/', 'lib/', 'node_modules/', 'jest.config.js' ], basePath: '/typescript-actions-monorepo', loose: false } ] +1s
  eslintrc:ignore-pattern   processed: { basePath: '/typescript-actions-monorepo', patterns: [ '/hello-world/**/node_modules/*', 'dist/', 'lib/', 'node_modules/', 'jest.config.js' ] } +2ms
```
