### PR TITLE
Remove matchPaths from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   ],
   "packageRules": [
     {
-      "matchPaths": ["*/**"],
+      "description": "Update per action",
       "additionalBranchPrefix": "{{packageFileDir}}-",
       "commitMessageSuffix": "({{packageFileDir}})",
       "excludePackageNames": [


### PR DESCRIPTION
> https://docs.renovatebot.com/release-notes-for-major-versions/
> matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed

